### PR TITLE
Add display option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 2.2.0
-* `displayOption` の型を追加
+* `displayOptions` の型を追加
 * `backgroundImage`, `backgroundColor` を非推奨へ
 
 ## 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.0
+* `displayOption` の型を追加
+* `backgroundImage`, `backgroundColor` を非推奨へ
+
 ## 2.1.0
 * `warn` の型を追加
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ sandbox.config.js の型定義を提供します。
 
 ## 各プロパティの説明
 * autoSendEventName: コンテンツ起動時にイベントを自動送信するイベント名
-* backgroundImage: 画像のローカルパス、もしくは URL を指定することでコンテンツ実行画面の背景に画像を表示
-* backgroundColor: コンテンツ実行画面の背景色
 * showMenu: ページ読み込み時にデベロッパーメニューを表示するか否か。省略時は偽
 * events: コンテンツで扱う playlog イベント
 * arguments: コンテンツの起動時に渡される引数
@@ -23,6 +21,13 @@ sandbox.config.js の型定義を提供します。
   * useMathRandom: Math.random() の警告を出すかどうか
   * drawOutOfCanvas: 範囲外描画されている場合に警告を出すかどうか
   * drawDestinationEmpty: 描画先が空の場合に警告を出すかどうか
+* displayOption: 各種表示設定
+  * fitsToScreen: ゲーム画面をブラウザサイズに合わせて拡縮するか
+  * backgroundImage: 画像のローカルパス、もしくは URL を指定することでコンテンツ実行画面の背景に画像を表示
+  * backgroundColor: コンテンツ実行画面の背景色
+  * showsGrid: グリッドを表示するか
+  * showsProfiler: FPS などを表示するか。
+  * showsDesignGuideline: ニコ生ゲームのデザインガイドライン画像を表示するか
 
 詳細は [SandboxConfiguration.ts の定義とコメント][SandboxConfiguration-link]を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sandbox.config.js の型定義を提供します。
   * useMathRandom: Math.random() の警告を出すかどうか
   * drawOutOfCanvas: 範囲外描画されている場合に警告を出すかどうか
   * drawDestinationEmpty: 描画先が空の場合に警告を出すかどうか
-* displayOption: 各種表示設定
+* displayOptions: 各種表示設定
   * fitsToScreen: ゲーム画面をブラウザサイズに合わせて拡縮するか
   * backgroundImage: 画像のローカルパス、もしくは URL を指定することでコンテンツ実行画面の背景に画像を表示
   * backgroundColor: コンテンツ実行画面の背景色

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/sandbox-configuration",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/sandbox-configuration",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@akashic/eslint-config": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/sandbox-configuration",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Type definitions and utilities for sandbox.config.js",
   "main": "lib/index.js",
   "scripts": {

--- a/src/SandboxConfiguration.ts
+++ b/src/SandboxConfiguration.ts
@@ -3,8 +3,7 @@
  */
 export interface SandboxConfiguration {
 	/**
-	 * @deprecated 非推奨。将来削除する予定。
-	 * autoSendEventName の使用が正となる。autoSendEventName が存在する場合にこの値は無視される。
+	 * @deprecated 非推奨。将来削除する予定。代わりに `autoSendEventName` を利用すること。 autoSendEventName が存在する場合にこの値は無視される。
 	 */
 	autoSendEvents?: string | null;
 	/**
@@ -12,13 +11,11 @@ export interface SandboxConfiguration {
 	 */
 	autoSendEventName?: string | null;
 	/**
-	 * @deprecated 非推奨。将来削除する予定。
-	 * `displayOptions.backgroundImage` の使用が正となる。displayOptions.backgroundImage が存在する場合にこの値は無視される。
+	 * @deprecated 非推奨。将来削除する予定。代わりに `displayOptions.backgroundImage` を利用すること。displayOptions.backgroundImage が存在する場合にこの値は無視される。
 	 */
 	backgroundImage?: string | null;
 	/**
-	 * @deprecated 非推奨。将来削除する予定。
-	 * `displayOptions.backgroundColor` の使用が正となる。displayOptions.backgroundColor が存在する場合にこの値は無視される。
+	 * @deprecated 非推奨。将来削除する予定。代わりに `displayOptions.backgroundColor` を利用すること。displayOptions.backgroundColor が存在する場合にこの値は無視される。
 	 */
 	backgroundColor?: string | null;
 	/**
@@ -53,7 +50,7 @@ export interface SandboxConfiguration {
 		};
 	};
 	/**
-	 * サーバ側で利用できる外部プラグインを登録
+	 * サーバ側で利用できる外部プラグインを登録。
 	 */
 	server?: {
 		external?: {
@@ -61,23 +58,23 @@ export interface SandboxConfiguration {
 		};
 	};
 	/**
-	 * 各種警告表示設定
-	 * 真の場合は警告を表示する
+	 * 各種警告表示設定。
+	 * 真の場合は警告を表示する。
 	 */
 	warn?: {
-		/** ES6以降でサポートされるオブジェクトが使われている場合警告を出すかどうか  */
+		/** ES6以降でサポートされるオブジェクトが使われている場合警告を出すかどうか。  */
 		es6?: boolean;
-		/** Date の警告を出すかどうか */
+		/** Date の警告を出すかどうか。 */
 		useDate?: boolean;
-		/** Math.random() の警告を出すかどうか */
+		/** Math.random() の警告を出すかどうか。 */
 		useMathRandom?: boolean;
-		/** 範囲外描画されている場合に警告を出すかどうか */
+		/** 範囲外描画されている場合に警告を出すかどうか。 */
 		drawOutOfCanvas?: boolean;
-		/** 描画先が空の場合に警告を出すかどうか */
+		/** 描画先が空の場合に警告を出すかどうか。 */
 		drawDestinationEmpty?: boolean;
 	};
 	/**
-	 * s各種表示設定
+	 * 各種表示設定。
 	 */
 	displayOptions?: {
 		/**
@@ -107,10 +104,11 @@ export interface SandboxConfiguration {
 	};
 }
 
-type OmitProperty = "autoSendEvents" | "backgroundImage" | "backgroundColor";
+type DeprecatedProperties = "autoSendEvents" | "backgroundImage" | "backgroundColor";
 /**
  * 正規化した SandboxConfiguration のインターフェース
  */
-export interface NormalizedSandboxConfiguration extends Required<Omit<SandboxConfiguration, OmitProperty>> {
+export interface NormalizedSandboxConfiguration extends Required<Omit<SandboxConfiguration, DeprecatedProperties>> {
 	warn: Required<Required<SandboxConfiguration>["warn"]>;
+	displayOptions: Required<Required<SandboxConfiguration>["displayOptions"]>;
 }

--- a/src/SandboxConfiguration.ts
+++ b/src/SandboxConfiguration.ts
@@ -12,11 +12,13 @@ export interface SandboxConfiguration {
 	 */
 	autoSendEventName?: string | null;
 	/**
-	 * 画像のローカルパス、もしくは URL を指定することでコンテンツ実行画面の背景に画像を表示する。
+	 * @deprecated 非推奨。将来削除する予定。
+	 * `displayOption.backgroundImage` の使用が正となる。displayOption.backgroundImage が存在する場合にこの値は無視される。
 	 */
 	backgroundImage?: string | null;
 	/**
-	 * コンテンツ実行画面の背景色。
+	 * @deprecated 非推奨。将来削除する予定。
+	 * `displayOption.backgroundColor` の使用が正となる。displayOption.backgroundColor が存在する場合にこの値は無視される。
 	 */
 	backgroundColor?: string | null;
 	/**
@@ -74,11 +76,41 @@ export interface SandboxConfiguration {
 		/** 描画先が空の場合に警告を出すかどうか */
 		drawDestinationEmpty?: boolean;
 	};
+	/**
+	 * s各種表示設定
+	 */
+	displayOption?: {
+		/**
+		 * ゲーム画面をブラウザサイズに合わせて拡縮するか。
+		 */
+		fitsToScreen?: boolean | null;
+		/**
+		 * 画像のローカルパス、もしくは URL を指定することでコンテンツ実行画面の背景に画像を表示する。
+		 */
+		backgroundImage?: string | null;
+		/**
+		 * コンテンツ実行画面の背景色。
+		 */
+		backgroundColor?: string | null;
+		/**
+		 * グリッドを表示するか。
+		 */
+		showsGrid?: boolean | null;
+		/**
+		 * FPS などを表示するか。
+		 */
+		showsProfiler?: boolean | null;
+		/**
+		 * ニコ生ゲームのデザインガイドライン画像を表示するか。
+		 */
+		showsDesignGuideline?: boolean | null;
+	};
 }
 
+type OmitProperty = "autoSendEvents" | "backgroundImage" | "backgroundColor";
 /**
  * 正規化した SandboxConfiguration のインターフェース
  */
-export interface NormalizedSandboxConfiguration extends Required<Omit<SandboxConfiguration, "autoSendEvents">> {
+export interface NormalizedSandboxConfiguration extends Required<Omit<SandboxConfiguration, OmitProperty>> {
 	warn: Required<Required<SandboxConfiguration>["warn"]>;
 }

--- a/src/SandboxConfiguration.ts
+++ b/src/SandboxConfiguration.ts
@@ -13,12 +13,12 @@ export interface SandboxConfiguration {
 	autoSendEventName?: string | null;
 	/**
 	 * @deprecated 非推奨。将来削除する予定。
-	 * `displayOption.backgroundImage` の使用が正となる。displayOption.backgroundImage が存在する場合にこの値は無視される。
+	 * `displayOptions.backgroundImage` の使用が正となる。displayOptions.backgroundImage が存在する場合にこの値は無視される。
 	 */
 	backgroundImage?: string | null;
 	/**
 	 * @deprecated 非推奨。将来削除する予定。
-	 * `displayOption.backgroundColor` の使用が正となる。displayOption.backgroundColor が存在する場合にこの値は無視される。
+	 * `displayOptions.backgroundColor` の使用が正となる。displayOptions.backgroundColor が存在する場合にこの値は無視される。
 	 */
 	backgroundColor?: string | null;
 	/**
@@ -79,7 +79,7 @@ export interface SandboxConfiguration {
 	/**
 	 * s各種表示設定
 	 */
-	displayOption?: {
+	displayOptions?: {
 		/**
 		 * ゲーム画面をブラウザサイズに合わせて拡縮するか。
 		 */

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -133,8 +133,8 @@ describe("utils", () => {
 			expect(conf.warn.drawOutOfCanvas).toBeTruthy();
 			expect(conf.warn.drawDestinationEmpty).toBeTruthy();
 			expect(conf.displayOptions.fitsToScreen).toBeFalsy();
-			expect(conf.displayOptions.backgroundImage).toBe("");
-			expect(conf.displayOptions.backgroundColor).toBe("");
+			expect(conf.displayOptions.backgroundImage).toBeNull();
+			expect(conf.displayOptions.backgroundColor).toBeNull();
 			expect(conf.displayOptions.showsGrid).toBeFalsy();
 			expect(conf.displayOptions.showsProfiler).toBeFalsy();
 			expect(conf.displayOptions.showsDesignGuideline).toBeFalsy();

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -26,7 +26,7 @@ describe("utils", () => {
 			drawOutOfCanvas: false,
 			drawDestinationEmpty: false
 		},
-		displayOption: {
+		displayOptions: {
 			fitsToScreen: true,
 			backgroundImage: "./some/path",
 			backgroundColor: "blue",
@@ -132,7 +132,7 @@ describe("utils", () => {
 			expect(conf.warn.useMathRandom).toBeTruthy();
 			expect(conf.warn.drawOutOfCanvas).toBeTruthy();
 			expect(conf.warn.drawDestinationEmpty).toBeTruthy();
-			expect(conf.displayOption).toEqual({});
+			expect(conf.displayOptions).toEqual({});
 		});
 
 		it("autoSendEvents and autoSendEventName exist", () => {
@@ -150,18 +150,18 @@ describe("utils", () => {
 			expect(conf.warn.useMathRandom).toBeFalsy();
 			expect(conf.warn.drawOutOfCanvas).toBeFalsy();
 			expect(conf.warn.drawDestinationEmpty).toBeFalsy();
-			expect(conf.displayOption.fitsToScreen).toBeTruthy();
-			expect(conf.displayOption.backgroundImage).toBe("./some/path");
-			expect(conf.displayOption.backgroundColor).toBe("blue");
-			expect(conf.displayOption.showsGrid).toBeFalsy();
-			expect(conf.displayOption.showsProfiler).toBeTruthy();
-			expect(conf.displayOption.showsDesignGuideline).toBeFalsy();
+			expect(conf.displayOptions.fitsToScreen).toBeTruthy();
+			expect(conf.displayOptions.backgroundImage).toBe("./some/path");
+			expect(conf.displayOptions.backgroundColor).toBe("blue");
+			expect(conf.displayOptions.showsGrid).toBeFalsy();
+			expect(conf.displayOptions.showsProfiler).toBeTruthy();
+			expect(conf.displayOptions.showsDesignGuideline).toBeFalsy();
 		});
 
 		it("Assign to displayOption if backgroundImage, backgroundColor exist and displayOption does not exist", () => {
 			const conf = utils.normalize(conf2);
-			expect(conf.displayOption.backgroundColor).toBe("red");
-			expect(conf.displayOption.backgroundImage).toBe("./some/path");
+			expect(conf.displayOptions.backgroundColor).toBe("red");
+			expect(conf.displayOptions.backgroundImage).toBe("./some/path");
 		});
 
 		it("When only autoSendEventName, nothing changes", () => {

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -25,6 +25,14 @@ describe("utils", () => {
 			useMathRandom: false,
 			drawOutOfCanvas: false,
 			drawDestinationEmpty: false
+		},
+		displayOption: {
+			fitsToScreen: true,
+			backgroundImage: "./some/path",
+			backgroundColor: "blue",
+			showsGrid: false,
+			showsProfiler: true,
+			showsDesignGuideline: false
 		}
 	};
 	const conf2: SandboxConfiguration = {
@@ -32,6 +40,8 @@ describe("utils", () => {
 		events: {
 			autoSendEventName2: []
 		},
+		backgroundImage: "./some/path",
+		backgroundColor: "red",
 		server: {
 			external: {
 				fooPlugin: "./fooPlugin.js"
@@ -110,8 +120,6 @@ describe("utils", () => {
 			const conf = utils.normalize({});
 			expect(conf.autoSendEventName).toBeNull();
 			expect(conf.hasOwnProperty("autoSendEvents")).toBeFalsy();
-			expect(conf.backgroundImage).toBeNull();
-			expect(conf.backgroundColor).toBeNull();
 			expect(conf.showMenu).toBeFalsy();
 			expect(conf.events).toEqual({});
 			expect(conf.arguments).toEqual({});
@@ -124,13 +132,12 @@ describe("utils", () => {
 			expect(conf.warn.useMathRandom).toBeTruthy();
 			expect(conf.warn.drawOutOfCanvas).toBeTruthy();
 			expect(conf.warn.drawDestinationEmpty).toBeTruthy();
+			expect(conf.displayOption).toEqual({});
 		});
 
 		it("autoSendEvents and autoSendEventName exist", () => {
 			const conf = utils.normalize(conf1);
 			expect(conf.autoSendEventName).toBe("autoSendEventName1");
-			expect(conf.backgroundImage).toBe("./path");
-			expect(conf.backgroundColor).toBe("red");
 			expect(conf.showMenu).toBeTruthy();
 			expect(conf.events).toEqual({ autoSendEvents1: [], autoSendEventName1: [] });
 			expect(conf.arguments).toEqual({});
@@ -143,6 +150,18 @@ describe("utils", () => {
 			expect(conf.warn.useMathRandom).toBeFalsy();
 			expect(conf.warn.drawOutOfCanvas).toBeFalsy();
 			expect(conf.warn.drawDestinationEmpty).toBeFalsy();
+			expect(conf.displayOption.fitsToScreen).toBeTruthy();
+			expect(conf.displayOption.backgroundImage).toBe("./some/path");
+			expect(conf.displayOption.backgroundColor).toBe("blue");
+			expect(conf.displayOption.showsGrid).toBeFalsy();
+			expect(conf.displayOption.showsProfiler).toBeTruthy();
+			expect(conf.displayOption.showsDesignGuideline).toBeFalsy();
+		});
+
+		it("Assign to displayOption if backgroundImage, backgroundColor exist and displayOption does not exist", () => {
+			const conf = utils.normalize(conf2);
+			expect(conf.displayOption.backgroundColor).toBe("red");
+			expect(conf.displayOption.backgroundImage).toBe("./some/path");
 		});
 
 		it("When only autoSendEventName, nothing changes", () => {

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -132,7 +132,12 @@ describe("utils", () => {
 			expect(conf.warn.useMathRandom).toBeTruthy();
 			expect(conf.warn.drawOutOfCanvas).toBeTruthy();
 			expect(conf.warn.drawDestinationEmpty).toBeTruthy();
-			expect(conf.displayOptions).toEqual({});
+			expect(conf.displayOptions.fitsToScreen).toBeFalsy();
+			expect(conf.displayOptions.backgroundImage).toBe("");
+			expect(conf.displayOptions.backgroundColor).toBe("");
+			expect(conf.displayOptions.showsGrid).toBeFalsy();
+			expect(conf.displayOptions.showsProfiler).toBeFalsy();
+			expect(conf.displayOptions.showsDesignGuideline).toBeFalsy();
 		});
 
 		it("autoSendEvents and autoSendEventName exist", () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -39,15 +39,15 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 	}
 
 	// TODO: `backgroundColor`, `backgroundImage` は非推奨。削除時にこのパスも削除。
-	// `backgroundColor`, `backgroundImage` のみの場合、displayOption に値を差し替える。
-	if (!sandboxConfig.displayOption) sandboxConfig.displayOption = {};
+	// `backgroundColor`, `backgroundImage` のみの場合、displayOptions に値を差し替える。
+	if (!sandboxConfig.displayOptions) sandboxConfig.displayOptions = {};
 	if (sandboxConfig.backgroundColor) {
 		console.warn("[deprecated] `backgroundImage` in sandbox.config.js is deprecated. Please use `displayOption.backgroundImage`.");
-		if (!sandboxConfig.displayOption.backgroundImage) sandboxConfig.displayOption.backgroundImage = sandboxConfig.backgroundImage;
+		if (!sandboxConfig.displayOptions.backgroundImage) sandboxConfig.displayOptions.backgroundImage = sandboxConfig.backgroundImage;
 	}
 	if (sandboxConfig.backgroundColor) {
 		console.warn("[deprecated] `backgroundColor` in sandbox.config.js is deprecated. Please use `displayOption.backgroundColor`.");
-		if (!sandboxConfig.displayOption.backgroundColor) sandboxConfig.displayOption.backgroundColor = sandboxConfig.backgroundColor;
+		if (!sandboxConfig.displayOptions.backgroundColor) sandboxConfig.displayOptions.backgroundColor = sandboxConfig.backgroundColor;
 	}
 
 	const warnValue = {
@@ -73,6 +73,6 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 			external: { ...(sandboxConfig.client?.external ?? {}) }
 		},
 		warn: warnValue,
-		displayOption: { ...(sandboxConfig.displayOption ?? {}) }
+		displayOptions: { ...(sandboxConfig.displayOptions ?? {}) }
 	};
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -29,7 +29,7 @@ export function getServerExternalFactory(sandboxConfig: SandboxConfiguration): (
  * 正規化
  */
 export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandboxConfiguration {
-	const { events, autoSendEvents, autoSendEventName, warn } = sandboxConfig;
+	const { events, autoSendEvents, autoSendEventName, warn, displayOptions } = sandboxConfig;
 	let autoSendEventsValue = null;
 	if (!autoSendEventName && events && autoSendEvents && events[autoSendEvents] instanceof Array) {
 		// TODO: `autoSendEvents` は非推奨。`autoSendEvents` の削除時にこのパスも削除する。
@@ -38,16 +38,24 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 		autoSendEventsValue = autoSendEvents;
 	}
 
+	const displayOptionsValue = {
+		fitsToScreen: displayOptions?.fitsToScreen ?? false,
+		backgroundImage: displayOptions?.backgroundImage ?? "",
+		backgroundColor: displayOptions?.backgroundColor ?? "",
+		showsGrid: displayOptions?.showsGrid ?? false,
+		showsProfiler: displayOptions?.showsProfiler ?? false,
+		showsDesignGuideline: displayOptions?.showsDesignGuideline ?? false
+	};
+
 	// TODO: `backgroundColor`, `backgroundImage` は非推奨。削除時にこのパスも削除。
 	// `backgroundColor`, `backgroundImage` のみの場合、displayOptions に値を差し替える。
-	if (!sandboxConfig.displayOptions) sandboxConfig.displayOptions = {};
-	if (sandboxConfig.backgroundColor) {
+	if (sandboxConfig.backgroundImage) {
 		console.warn("[deprecated] `backgroundImage` in sandbox.config.js is deprecated. Please use `displayOption.backgroundImage`.");
-		if (!sandboxConfig.displayOptions.backgroundImage) sandboxConfig.displayOptions.backgroundImage = sandboxConfig.backgroundImage;
+		if (!displayOptionsValue.backgroundImage) displayOptionsValue.backgroundImage = sandboxConfig.backgroundImage;
 	}
 	if (sandboxConfig.backgroundColor) {
 		console.warn("[deprecated] `backgroundColor` in sandbox.config.js is deprecated. Please use `displayOption.backgroundColor`.");
-		if (!sandboxConfig.displayOptions.backgroundColor) sandboxConfig.displayOptions.backgroundColor = sandboxConfig.backgroundColor;
+		if (!displayOptionsValue.backgroundColor) displayOptionsValue.backgroundColor = sandboxConfig.backgroundColor;
 	}
 
 	const warnValue = {
@@ -73,6 +81,6 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 			external: { ...(sandboxConfig.client?.external ?? {}) }
 		},
 		warn: warnValue,
-		displayOptions: { ...(sandboxConfig.displayOptions ?? {}) }
+		displayOptions: displayOptionsValue
 	};
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -38,6 +38,18 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 		autoSendEventsValue = autoSendEvents;
 	}
 
+	// TODO: `backgroundColor`, `backgroundImage` は非推奨。削除時にこのパスも削除。
+	// `backgroundColor`, `backgroundImage` のみの場合、displayOption に値を差し替える。
+	if (!sandboxConfig.displayOption) sandboxConfig.displayOption = {};
+	if (sandboxConfig.backgroundColor) {
+		console.warn("[deprecated] `backgroundImage` in sandbox.config.js is deprecated. Please use `displayOption.backgroundImage`.");
+		if (!sandboxConfig.displayOption.backgroundImage) sandboxConfig.displayOption.backgroundImage = sandboxConfig.backgroundImage;
+	}
+	if (sandboxConfig.backgroundColor) {
+		console.warn("[deprecated] `backgroundColor` in sandbox.config.js is deprecated. Please use `displayOption.backgroundColor`.");
+		if (!sandboxConfig.displayOption.backgroundColor) sandboxConfig.displayOption.backgroundColor = sandboxConfig.backgroundColor;
+	}
+
 	const warnValue = {
 		es6: warn?.es6 ?? true,
 		useDate: warn?.useDate ?? true,
@@ -49,8 +61,6 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 	return {
 		...sandboxConfig, // 型に存在しない値が残るようにする
 		autoSendEventName: autoSendEventsValue ?? sandboxConfig.autoSendEventName ?? null,
-		backgroundImage: sandboxConfig.backgroundImage ?? null,
-		backgroundColor: sandboxConfig.backgroundColor ?? null,
 		showMenu: sandboxConfig.showMenu ?? false,
 		events: sandboxConfig.events ?? {},
 		arguments: sandboxConfig.arguments ?? {},
@@ -62,6 +72,7 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 		client: {
 			external: { ...(sandboxConfig.client?.external ?? {}) }
 		},
-		warn: warnValue
+		warn: warnValue,
+		displayOption: { ...(sandboxConfig.displayOption ?? {}) }
 	};
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,8 +40,8 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 
 	const displayOptionsValue = {
 		fitsToScreen: displayOptions?.fitsToScreen ?? false,
-		backgroundImage: displayOptions?.backgroundImage ?? "",
-		backgroundColor: displayOptions?.backgroundColor ?? "",
+		backgroundImage: displayOptions?.backgroundImage ?? null,
+		backgroundColor: displayOptions?.backgroundColor ?? null,
 		showsGrid: displayOptions?.showsGrid ?? false,
 		showsProfiler: displayOptions?.showsProfiler ?? false,
 		showsDesignGuideline: displayOptions?.showsDesignGuideline ?? false
@@ -51,11 +51,12 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 	// `backgroundColor`, `backgroundImage` のみの場合、displayOptions に値を差し替える。
 	if (sandboxConfig.backgroundImage) {
 		console.warn("[deprecated] `backgroundImage` in sandbox.config.js is deprecated. Please use `displayOption.backgroundImage`.");
-		if (!displayOptionsValue.backgroundImage) displayOptionsValue.backgroundImage = sandboxConfig.backgroundImage;
+		if (displayOptionsValue.backgroundImage === null) displayOptionsValue.backgroundImage = sandboxConfig.backgroundImage;
+
 	}
 	if (sandboxConfig.backgroundColor) {
 		console.warn("[deprecated] `backgroundColor` in sandbox.config.js is deprecated. Please use `displayOption.backgroundColor`.");
-		if (!displayOptionsValue.backgroundColor) displayOptionsValue.backgroundColor = sandboxConfig.backgroundColor;
+		if (displayOptionsValue.backgroundColor === null) displayOptionsValue.backgroundColor = sandboxConfig.backgroundColor;
 	}
 
 	const warnValue = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -52,7 +52,6 @@ export function normalize(sandboxConfig: SandboxConfiguration): NormalizedSandbo
 	if (sandboxConfig.backgroundImage) {
 		console.warn("[deprecated] `backgroundImage` in sandbox.config.js is deprecated. Please use `displayOption.backgroundImage`.");
 		if (displayOptionsValue.backgroundImage === null) displayOptionsValue.backgroundImage = sandboxConfig.backgroundImage;
-
 	}
 	if (sandboxConfig.backgroundColor) {
 		console.warn("[deprecated] `backgroundColor` in sandbox.config.js is deprecated. Please use `displayOption.backgroundColor`.");


### PR DESCRIPTION
## 概要

-  `displayOptions` の型を追加します。以下のプロパティを持ちます。
    - fitsToScreen
    - backgroundImage
    - backgroundColor
    - showsGrid
    - showsProfiler
    - showsDesignGuideline

- `backgroundImage`, `backgroundColor` を非推奨へ
    - `utils.normailze()` で `backgroundImage`, `backgroundColor` のみで displayOptions の `backgroundImage`, `backgroundColor が存在しない場合は、displayOptions へ値を差し替えます。

