### PR TITLE
update workflows for security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,24 @@ env:
   NODE_VERSION: 18
   cache-version: v1
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Publish and Release
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         env:
           cache-name: cache-node-modules
         with:
@@ -37,7 +42,7 @@ jobs:
           npm run build
           npm test
       - name: Publish and Release
-        uses: akashic-games/action-release@v2
+        uses: akashic-games/action-release@e4e3c8901b8ed92356c5eb9cf6cfc573a9c4ce9b # v2.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 env:
   cache-version: v1
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,11 +18,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         node: [18.x, 20.x]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         env:
           cache-name: cache-node-modules
         with:
@@ -30,7 +33,9 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}-build-
             ${{ env.cache-version }}-${{ runner.os }}-
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
       - name: Run test
         run: |
           npm ci


### PR DESCRIPTION
### やったこと
- GithubActionsワークフローのセキュリティ対応
  - 各モジュール使用時にバージョンやタグではなく、SHA PINを指定
    - SHA PINの指定のために、pinactを利用
  - permissionsの指定
  - checkout アクションに`persist-credentials: false`追加